### PR TITLE
Fall back to cDNA fasta headers for annotation

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,47 @@
+name: Test annotation manipulation
+
+on: [pull_request]
+
+jobs:
+  setup:
+    name: ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "macos-latest"]
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Add workspace to path
+        run: |
+          echo "${GITHUB_WORKSPACE}" >> $GITHUB_PATH
+
+      - name: Cache conda
+        uses: actions/cache@v1
+        env:
+          # Increase this value to reset cache if etc/example-environment.yml has not changed
+          CACHE_NUMBER: 0
+        with:
+          path: ~/conda_pkgs_dir
+          key:
+            ${{ matrix.os }}-conda-${{ env.CACHE_NUMBER }}-${{hashFiles('test-environment.yml') }}
+      
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: test
+          environment-file: test-environment.yml
+          python-version: 3.6
+          mamba-version: "*"
+          channels: conda-forge,bioconda,defaults
+          allow-softlinks: true
+          channel-priority: flexible
+          show-channel-urls: true
+          use-only-tar-bz2: true
+      
+      - name: Run tests
+        run: |
+          atlas-gene-annotation-manipulation-post-install-tests.sh

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -35,7 +35,6 @@ jobs:
           activate-environment: test
           environment-file: test-environment.yml
           python-version: 3.6
-          mamba-version: "*"
           channels: conda-forge,bioconda,defaults
           allow-softlinks: true
           channel-priority: flexible

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ gtf2featureAnnotation.R --help
 ```
 
 ```
-Usage: ./gtf2featureAnnotation.R [options]
+Usage: gtf2featureAnnotation.R [options]
 
 
 Options:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ gtf2featureAnnotation.R --help
 ```
 
 ```
-Usage: gtf2featureAnnotation.R [options]
+Usage: ./gtf2featureAnnotation.R [options]
 
 
 Options:
@@ -49,14 +49,20 @@ Options:
     -p MITO-BIOTYPES, --mito-biotypes=MITO-BIOTYPES
         If specified,  marks in a column called "mito" features with the specified biotypes (case insensitve)
 
-    -c FILTER-CDNAS, --filter-cdnas=FILTER-CDNAS
-        If specified, sequences in the provided FASTA-format cDNAs file will be filtered to remove entries not present in the annotation
+    -c PARSE-CDNAS, --parse-cdnas=PARSE-CDNAS
+        Provide a cDNA file for extracting meta info and/or filtering.
 
-    -d FILTER-CDNAS-FIELD, --filter-cdnas-field=FILTER-CDNAS-FIELD
-        Where --filter-cdnas is specified, what field should be used to compare to identfiers from the FASTA?
+    -y, --parse-cdna-names
+        Where --parse-cdnas is specified, parse out info from the Fasta name. Will likely only work for Ensembl GTFs
+
+    -d PARSE-CDNA-FIELD, --parse-cdna-field=PARSE-CDNA-FIELD
+        Where --parse-cdnas is specified, what field should be used to compare to identfiers from the FASTA?
+
+    -i FILL-EMPTY, --fill-empty=FILL-EMPTY
+        Where --fields is specified, fill empty specified columns with the content of the specified field. Useful when you need to guarantee a value, for example a gene ID for a transcript/gene mapping. 
 
     -e FILTER-CDNAS-OUTPUT, --filter-cdnas-output=FILTER-CDNAS-OUTPUT
-        Where --filter-cdnas is specified, what file should the filtered sequences be output to?
+        Where --parse-cdnas is specified, filter sequences and output to the specified file. No file will be output if this is not specified (for example for use of --dummy-from-cdnas only).
 
     -u, --version-transcripts
         Where the GTF contains transcript versions, should these be appended to transcript identifiers? Useful when generating transcript/gene mappings for use with transcriptomes. NOTE: if --filter-cdnas-field is set, the setting of this field is set to best match transcript identifiers in the cDNAs FASTA.
@@ -72,28 +78,41 @@ Options:
 
 This script should be able to produce tabular text files compiling any of the information present in a GTF file, e.g. for passing to downstream analysis.
 
-### Make a trasnscript-to-gene ID mapping for use with e.g. Kallisto, Salmon etc:
+### Make a table of all gene annotations in a GTF file
+
+```
+gtf2featureAnnotation.R \
+    --gtf-file <INPUT GTF> \
+    --feature-type "gene" \
+    --first-field "gene_id" \
+    --output-file <OUTPUT TEXT FILE FOR TABLE>
+```
+
+### Make a gene ID/ gene symbol mapping
+
+```
+gtf2featureAnnotation.R \
+    --gtf-file <INPUT GTF> \
+    --feature-type "gene" \
+    --fields "gene_id,gene_name"
+    --first-field "gene_id" \
+    --output-file <OUTPUT TEXT FILE FOR TABLE> \
+```
+
+### Make a transcript-to-gene ID mapping for use with e.g. Kallisto, Salmon etc:
 
 This is a common thing to need: get a mapping of transcript ID to gene ID. So we tell the script we want to extract annotations for 'transcript' feature types, and just have transcript and gene IDs in the output table.
 
 ```
 gtf2featureAnnotation.R \
-    --gtf-file <input GTF> 
-    --no-header \
-    --version-transcripts \ 
+    --gtf-file <INPUT GTF> \
+    --version-transcripts \
     --feature-type "transcript" \
-    --fields "transcript_id,gene_id" \
     --first-field "transcript_id" \
-    --output-file <OUTPUT TEXT FILE FOR TABLE>
+    --output-file <OUTPUT TEXT FILE FOR TABLE> \
+    --fields "transcript_id,gene_id" \
+    --no-header
 ```
-
-Parameter meanings:
-
- - `--no-header`: Do not apply a header to the output file
- - `--version-transcripts`: A flag which specifies that the transcript versions commonly found in Ensembl GTF files, if present, should be appended to transcript identifiers.
- - `--fields`: Comma-separated list of attributes to extract
- - `--first-field`: Which field to place first in output? 
-
 
 ### Synchronise a cDNA file with the annotation
 
@@ -101,23 +120,39 @@ Sometimes it's important that there are no transcripts in a FASTA-format transcr
 
 ```
 gtf2featureAnnotation.R \
-    --gtf-file <input GTF> 
-    --no-header \
-    --version-transcripts \ 
+    --gtf-file <INPUT GTF> \
+    --version-transcripts \
+    --parse-cdnas <REFERENCE CDNA FASTA> \
+    --parse-cdna-field "transcript_id" \
     --feature-type "transcript" \
-    --fields "transcript_id,gene_id" \
-    --first-field "transcript_id" \
+    --first-field "transcript_id" 
     --output-file <OUTPUT TEXT FILE FOR TABLE> \
-    --filter-cdnas reference.fa.gz \
-    --filter-cdnas-field "transcript_id" \
-    --filter-cdnas-output <OUTPUT FASTA FILE> 
+    --fields "transcript_id,gene_id" \
+    --no-header \
+    --filter-cdnas-output <FILTERED CDNA OUTPUT FILE>
 ```
 
 Output will be a an annotation table, and a FASTA-format cDNAs file with unannotated transcripts removed.
 
-The additional fields here specify:
-
- - `--filer-cdnas`: FASTA-format cDNAs file to filter for matches with the annotation
- - `--filter-cdnas-field`: which field in the annotation should match the transript identifiers
-
 When running in this way, the annotation talbe that's output needs to match the cDNAs file. So the `--version-transcripts` setting is overriden internally using whichever of versioned or unversioned identifiers match the transcript identifiers. We have found Ensembl to be a little inconsistent in this.
+
+### Synchronise an annotation file with the cDNA
+
+Alternatively, you may want to do the converse to the above, and make the annotation file match the cDNA:
+
+```
+gtf2featureAnnotation.R \
+    --gtf-file <INPUT GTF> \
+    --version-transcripts \
+    --parse-cdnas <REFERENCE CDNA FASTA> \
+    --parse-cdna-field "transcript_id" \
+    --feature-type "transcript" \
+    --parse-cdna-names \
+    --fill-empty transcript_id \
+    --first-field "transcript_id" \
+    --output-file <OUTPUT TEXT FILE FOR TABLE> \
+    --fields "transcript_id,gene_id" \
+    --no-header
+```
+
+There's no `--filter-cdnas-output` here so the Fasta won't be filtered. The --parse-cdna-names options will allow the Fasta headers to be searched for the annotation info- which is often present with Ensembl data. Failing that, the `--fill-empty` parameter will just copy the `transcript_id` to empty `gene_id` values. 

--- a/atlas-gene-annotation-manipulation-post-install-tests.sh
+++ b/atlas-gene-annotation-manipulation-post-install-tests.sh
@@ -33,7 +33,7 @@ setup() {
         skip "$test_gtf exists"
     fi
 
-    run rm -rf $test_gtf && wget -P $test_dir/data $test_cdna_uri && wget -P $test_dir/data $test_gtf_uri && zcat $test_gtf | grep -v Y110A7A.10.1 > $part_test_gtf
+    run rm -rf $test_gtf && wget -P $test_dir/data $test_cdna_uri && wget -P $test_dir/data $test_gtf_uri && gunzip -c $test_gtf | grep -v Y110A7A.10.1 > $part_test_gtf
 
     [ "$status" -eq 0 ]
     [ -f "$test_gtf" ]

--- a/atlas-gene-annotation-manipulation-post-install-tests.sh
+++ b/atlas-gene-annotation-manipulation-post-install-tests.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bats
+
+# Extract the test data
+setup() {
+    test_cdna_uri='http://ftp.ensembl.org/pub/release-104/fasta/caenorhabditis_elegans/cdna/Caenorhabditis_elegans.WBcel235.cdna.all.fa.gz'
+    test_gtf_uri='http://ftp.ensembl.org/pub/release-104/gtf/caenorhabditis_elegans/Caenorhabditis_elegans.WBcel235.104.gtf.gz'
+
+    test_dir="post_install_tests"
+    data_dir="${test_dir}/data"
+    output_dir="${test_dir}/outputs"
+
+    test_cdna=${data_dir}/$(basename $test_cdna_uri)
+    test_gtf=${data_dir}/$(basename $test_gtf_uri)
+    part_test_gtf=${data_dir}/part.gtf
+
+    gene_anno=${output_dir}/gene_anno.txt
+    gene_id_to_symbol=${output_dir}/gene_id_to_symbol.txt
+    t2gene=${output_dir}/t2gene.txt
+    t2gene_part=${output_dir}/t2gene_part.txt
+    filtered_cdnas=${output_dir}/filtered.fa.gz
+
+    if [ ! -d "$data_dir" ]; then
+        mkdir -p $data_dir
+    fi
+
+    if [ ! -d "$output_dir" ]; then
+        mkdir -p $output_dir
+    fi
+}
+
+@test "Download test data from FTP" {
+    if  [ "$resume" = 'true' ] && [ -f "$test_gtf" ]; then
+        skip "$test_gtf exists"
+    fi
+
+    run rm -rf $test_gtf && wget -P $test_dir/data $test_cdna_uri && wget -P $test_dir/data $test_gtf_uri && zcat $test_gtf | grep -v Y110A7A.10.1 > $part_test_gtf
+
+    [ "$status" -eq 0 ]
+    [ -f "$test_gtf" ]
+}
+
+@test "Make a table of all gene annotation in a GTF file" {
+    if  [ "$resume" = 'true' ] && [ -f "$gene_anno" ]; then
+        skip "$gene_anno exists"
+    fi
+
+    run rm -rf $gene_anno && gtf2featureAnnotation.R --gtf-file $test_gtf --feature-type "gene" --first-field "gene_id" --output-file $gene_anno
+
+    [ "$status" -eq 0 ]
+    [ -f "$gene_anno" ]
+}
+
+@test "Make a gene ID/ gene symbol mapping from a GTF file" {
+    if  [ "$resume" = 'true' ] && [ -f "$gene_id_to_symbol" ]; then
+        skip "$gene_id_to_symbol exists"
+    fi
+
+    run rm -rf $gene_anno && gtf2featureAnnotation.R --gtf-file $test_gtf --feature-type "gene" --first-field "gene_id" --output-file $gene_id_to_symbol --first-field "gene_id" --fields "gene_id,gene_name"
+
+    [ "$status" -eq 0 ]
+    [ -f "$gene_id_to_symbol" ]
+}
+
+@test "Make a transcript to gene file from GTF only" {
+    if  [ "$resume" = 'true' ] && [ -f "$t2gene" ]; then
+        skip "$t2gene exists"
+    fi
+
+    run rm -rf $t2gene && gtf2featureAnnotation.R --gtf-file $test_gtf --version-transcripts --feature-type "transcript" --first-field "transcript_id" --output-file $t2gene --fields "transcript_id,gene_id" --no-header
+
+    [ "$status" -eq 0 ]
+    [ -f "$t2gene" ]
+}
+
+@test "Make a transcript to gene file (using transcriptome, some missing GTF lines)" {
+    if  [ "$resume" = 'true' ] && [ -f "$t2gene_part" ]; then
+        skip "$t2gene exists"
+    fi
+
+    run rm -rf $t2gene_part && gtf2featureAnnotation.R --gtf-file $part_test_gtf --version-transcripts --parse-cdnas $test_cdna  --parse-cdna-field "transcript_id" --feature-type "transcript" --parse-cdna-names --fill-empty transcript_id --first-field "transcript_id" --output-file $t2gene_part --fields "transcript_id,gene_id" --no-header
+
+    [ "$status" -eq 0 ]
+    [ -f "$t2gene_part" ]
+}
+
+@test "Check agreement of GTF and Fasta-derived gene IDs" {
+    run diff <(cat $t2gene | sort) <(cat $t2gene_part | sort)
+
+    [ "$status" -eq 0 ]
+    [ -f "$t2gene_part" ]
+}
+
+@test "Make a transcript to gene file and filter cDNAs to match" {
+    if  [ "$resume" = 'true' ] && [ -f "$filtered_cdnas" ]; then
+        skip "$filtered_cdnas exists"
+    fi
+
+    run rm -rf $filtered_cdnas && gtf2featureAnnotation.R --gtf-file $part_test_gtf --version-transcripts --parse-cdnas $test_cdna  --parse-cdna-field "transcript_id" --feature-type "transcript" --first-field "transcript_id" --output-file $t2gene_part --fields "transcript_id,gene_id" --no-header --filter-cdnas-output $filtered_cdnas
+
+    [ "$status" -eq 0 ]
+    [ -f "$filtered_cdnas" ]
+}
+

--- a/gtf2featureAnnotation.R
+++ b/gtf2featureAnnotation.R
@@ -222,7 +222,7 @@ if ( opt$feature_type == 'transcript' &&  all(c('transcript_id', 'transcript_ver
     print('Versioning transcripts')
   } else{
     opt$version_transcripts <- FALSE
-    print('Not versioning transcripts')
+    print('Not versioning transcripts (they do not look versioned)')
   }
 
   if ( opt$version_transcripts ){
@@ -251,11 +251,11 @@ if (! is.null(opt$parse_cdnas)){
   }
   
   # If we have transcripts with no annotation, see if we can get it from the fasta names
-  
+
   if (length(cdna_only) > 0 && ! is.null(opt$parse_cdna_names)){
     print(paste("Info missing from GTF for", length(cdna_only), "supplied cDNAs, trying to extract it from the cDNA FASTA headers"))
     tinfo <- plyr::rbind.fill(lapply(names(cdna_only), parse_ensembl_fasta_transcript_info))
-    anno <- plyr::rbind.fill(anno, tinfo)
+    anno <- plyr::rbind.fill(as.data.frame(anno), tinfo[,colnames(tinfo) %in% colnames(anno)])
   }
 }
 

--- a/gtf2featureAnnotation.R
+++ b/gtf2featureAnnotation.R
@@ -256,6 +256,8 @@ if (! is.null(opt$parse_cdnas)){
     print(paste("Info missing from GTF for", length(cdna_only), "supplied cDNAs, trying to extract it from the cDNA FASTA headers"))
     tinfo <- plyr::rbind.fill(lapply(names(cdna_only), parse_ensembl_fasta_transcript_info))
     anno <- plyr::rbind.fill(as.data.frame(anno), tinfo[,colnames(tinfo) %in% colnames(anno)])
+  }else{
+    print("No transcripts missing from GTF")
   }
 }
 

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -1,0 +1,6 @@
+name: test
+dependencies:
+  - bats 
+  - r-optparse 
+  - bioconductor-rtracklayer
+  - r-plyr


### PR DESCRIPTION
This PR was prompted by our desire to centralise reference files, such as Alevin indices. Having made Salmon indices for Ensembl cDNAs, I re-encountered the issue of Alevin [responding badly](https://github.com/COMBINE-lab/salmon/issues/336) when a transcript-gene mapping was derived from an associated GTF with some transcripts missing (as seems to be common in Ensembl). We could re-make the indices with cDNA files filtered to match but that's unappealing because it takes us further from what Ensembl actually provides. We could also make Alevin-specific cDNA assets, but that's wasteful.

Having thought harder about it, the better option is actually to match the annotation files to the cDNA, which we can do by:

1. Checking the fasta headers themselves to see if they contain the info we need, which they mostly do in Ensembl, and using that to annotate transcripts without annotation in the GTF.
2. Just copying transcript ids to fields like gene_id to keep Alevin et al happy (it's not that silly to consider some of the more obscure transcripts as gene sequences). In practice I don't think this fallback will happen with Ensembl files, since 1) should work most of the time. 

The changes here implement both of those things, allowing us to guarantee that **all transcripts are accounted for in annotation files** such as the transcript/ gene files we need for Alevin.

I've changed filter-cdnas options to parse-cdnas options to reflect the wider use of the cDNAs file (providing metadata as well as being filtered). 