### PR TITLE
Update gtf2featureAnnotation.R

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,7 +20,6 @@ jobs:
         uses: mamba-org/provision-with-micromamba@main
         with:
           environment-file: test-environment.yml
-          use-only-tar-bz2: true
 
       - name: Add workspace to path
         run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -16,31 +16,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: install mamba
+        uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: test-environment.yml
+          use-only-tar-bz2: true
+
       - name: Add workspace to path
         run: |
           echo "${GITHUB_WORKSPACE}" >> $GITHUB_PATH
 
-      - name: Cache conda
-        uses: actions/cache@v1
-        env:
-          # Increase this value to reset cache if etc/example-environment.yml has not changed
-          CACHE_NUMBER: 0
-        with:
-          path: ~/conda_pkgs_dir
-          key:
-            ${{ matrix.os }}-conda-${{ env.CACHE_NUMBER }}-${{hashFiles('test-environment.yml') }}
-      
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          activate-environment: test
-          environment-file: test-environment.yml
-          python-version: 3.6
-          channels: conda-forge,bioconda,defaults
-          allow-softlinks: true
-          channel-priority: flexible
-          show-channel-urls: true
-          use-only-tar-bz2: true
-      
       - name: Run tests
         run: |
           atlas-gene-annotation-manipulation-post-install-tests.sh

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   setup:
-    name: ${{ matrix.os }})
+    name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/atlas-gene-annotation-manipulation-post-install-tests.sh
+++ b/atlas-gene-annotation-manipulation-post-install-tests.sh
@@ -4,7 +4,8 @@
 setup() {
     test_cdna_uri='http://ftp.ensembl.org/pub/release-104/fasta/caenorhabditis_elegans/cdna/Caenorhabditis_elegans.WBcel235.cdna.all.fa.gz'
     test_gtf_uri='http://ftp.ensembl.org/pub/release-104/gtf/caenorhabditis_elegans/Caenorhabditis_elegans.WBcel235.104.gtf.gz'
-
+    test_wormbase_cdna_uri='http://ftp.ebi.ac.uk/pub/databases/wormbase/collaboration/EBI/GxA/latest/schistosoma_mansoni.PRJEA36577.WBPS15.mRNA_transcripts.fa.gz'
+    test_wormbase_gtf_uri='ftp://ftp.ebi.ac.uk/pub/databases/wormbase/collaboration/EBI/GxA/latest/schistosoma_mansoni.PRJEA36577.WBPS15.canonical_geneset.gtf.gz'
     test_dir="post_install_tests"
     data_dir="${test_dir}/data"
     output_dir="${test_dir}/outputs"
@@ -14,6 +15,11 @@ setup() {
     test_gene_to_remove=WBGene00000001
     part_test_gtf=${data_dir}/part.gtf
 
+    wormbase_test_cdna=${data_dir}/$(basename $test_wormbase_cdna_uri)
+    wormbase_test_gtf=${data_dir}/$(basename $test_wormbase_gtf_uri)
+    wormbase_test_gene_to_remove=Smp_329140
+    wormbase_part_test_gtf=${data_dir}/wormbase_part.gtf
+    
     gene_anno=${output_dir}/gene_anno.txt
     enriched_gene_anno=${output_dir}/enriched_gene_anno.txt
     gene_id_to_symbol=${output_dir}/gene_id_to_symbol.txt
@@ -22,6 +28,14 @@ setup() {
     t2gene_part_matched=${output_dir}/t2gene_part_matched.txt
     filtered_cdnas=${output_dir}/filtered.fa.gz
 
+    wormbase_gene_anno=${output_dir}/wormbase_gene_anno.txt
+    wormbase_enriched_gene_anno=${output_dir}/wormbase_enriched_gene_anno.txt
+    wormbase_gene_id_to_symbol=${output_dir}/wormbase_gene_id_to_symbol.txt
+    wormbase_t2gene=${output_dir}/wormbase_t2gene.txt
+    wormbase_t2gene_part=${output_dir}/wormbase_t2gene_part.txt
+    wormbase_t2gene_part_matched=${output_dir}/wormbase_t2gene_part_matched.txt
+    wormbase_filtered_cdnas=${output_dir}/wormbase_filtered.fa.gz
+    
     if [ ! -d "$data_dir" ]; then
         mkdir -p $data_dir
     fi
@@ -36,13 +50,12 @@ setup() {
         skip "$test_gtf exists"
     fi
 
-    run rm -f $test_gtf && rm -f $test_cdna && wget -P $test_dir/data $test_cdna_uri && wget -P $test_dir/data $test_gtf_uri && gunzip -c $test_gtf | grep -v $test_gene_to_remove > $part_test_gtf
-
+    run rm -f $test_gtf && rm -f $test_cdna && wget -P $test_dir/data $test_cdna_uri && wget -P $test_dir/data $test_gtf_uri && gunzip -c $test_gtf | grep -v $test_gene_to_remove > $part_test_gtf && wget -P $test_dir/data $test_wormbase_cdna_uri && wget -P $test_dir/data $test_wormbase_gtf_uri && gunzip -c $wormbase_test_gtf | grep -v $wormbase_test_gene_to_remove > $wormbase_part_test_gtf
     [ "$status" -eq 0 ]
     [ -f "$test_gtf" ]
 }
 
-@test "Make a table of all gene annotation in a GTF file" {
+@test "Make a table of all gene annotation in a GTF file (Ensembl)" {
     if  [ "$resume" = 'true' ] && [ -f "$gene_anno" ]; then
         skip "$gene_anno exists"
     fi
@@ -53,7 +66,18 @@ setup() {
     [ -f "$gene_anno" ]
 }
 
-@test "Make a gene ID/ gene symbol mapping from a GTF file" {
+@test "Make a table of all gene annotation in a GTF file (Wormbase)" {
+    if  [ "$resume" = 'true' ] && [ -f "$wormbase_gene_anno" ]; then
+        skip "$wormbase_gene_anno exists"
+    fi
+
+    run rm -rf $wormbase_gene_anno && gtf2featureAnnotation.R --gtf-file $wormbase_test_gtf --feature-type "gene" --first-field "gene_id" --output-file $wormbase_gene_anno
+
+    [ "$status" -eq 0 ]
+    [ -f "$wormbase_gene_anno" ]
+}
+
+@test "Make a gene ID/ gene symbol mapping from a GTF file (Ensembl)" {
     if  [ "$resume" = 'true' ] && [ -f "$gene_id_to_symbol" ]; then
         skip "$gene_id_to_symbol exists"
     fi
@@ -64,7 +88,18 @@ setup() {
     [ -f "$gene_id_to_symbol" ]
 }
 
-@test "Make a transcript to gene file from GTF only" {
+@test "Make a gene ID/ gene symbol mapping from a GTF file (Wormbase)" {
+    if  [ "$resume" = 'true' ] && [ -f "$wormbase_gene_id_to_symbol" ]; then
+        skip "$wormbase_gene_id_to_symbol exists"
+    fi
+
+    run rm -rf $wormbase_gene_id_to_symbol && gtf2featureAnnotation.R --gtf-file $wormbase_test_gtf --feature-type "gene" --first-field "gene_id" --output-file $wormbase_gene_id_to_symbol --first-field "gene_id" --fields "gene_id,gene_name"
+
+    [ "$status" -eq 0 ]
+    [ -f "$wormbase_gene_id_to_symbol" ]
+}
+
+@test "Make a transcript to gene file from GTF only (Ensembl)" {
     if  [ "$resume" = 'true' ] && [ -f "$t2gene" ]; then
         skip "$t2gene exists"
     fi
@@ -75,7 +110,18 @@ setup() {
     [ -f "$t2gene" ]
 }
 
-@test "Make a transcript to gene file (using transcriptome, some missing GTF lines)" {
+@test "Make a transcript to gene file from GTF only (Wormbase)" {
+    if  [ "$resume" = 'true' ] && [ -f "$wormbase_t2gene" ]; then
+        skip "$wormbae_t2gene exists"
+    fi
+
+    run rm -rf $wormbase_t2gene && gtf2featureAnnotation.R --gtf-file $wormbase_test_gtf --version-transcripts --feature-type "transcript" --first-field "transcript_id" --output-file $wormbase_t2gene --fields "transcript_id,gene_id" --no-header
+
+    [ "$status" -eq 0 ]
+    [ -f "$wormbase_t2gene" ]
+}
+
+@test "Make a transcript to gene file (using transcriptome, some missing GTF lines (Ensembl))" {
     if  [ "$resume" = 'true' ] && [ -f "$t2gene_part" ]; then
         skip "$t2gene_part exists"
     fi
@@ -86,13 +132,30 @@ setup() {
     [ -f "$t2gene_part" ]
 }
 
-@test "Check agreement of GTF and Fasta-derived gene IDs" {
+@test "Make a transcript to gene file (using transcriptome, some missing GTF lines (Wormbase))" {
+    if  [ "$resume" = 'true' ] && [ -f "$wormbase_t2gene_part" ]; then
+        skip "$wormbase_t2gene_part exists"
+    fi
+
+    run rm -rf $wormbase_t2gene_part && gtf2featureAnnotation.R --gtf-file $wormbase_part_test_gtf --version-transcripts --parse-cdnas $wormbase_test_cdna  --parse-cdna-field "transcript_id" --feature-type "transcript" --parse-cdna-names --fill-empty transcript_id --first-field "transcript_id" --output-file $wormbase_t2gene_part --fields "transcript_id,gene_id" --no-header
+
+    [ "$status" -eq 0 ]
+    [ -f "$wormbase_t2gene_part" ]
+}
+
+@test "Check agreement of GTF and Fasta-derived gene IDs (Ensembl)" {
     run diff <(cat $t2gene | sort) <(cat $t2gene_part | sort)
 
     [ "$status" -eq 0 ]
 }
 
-@test "Make a transcript to gene file and filter cDNAs to match" {
+@test "Check agreement of GTF and Fasta-derived gene IDs (Wormbase)" {
+    run diff <(cat $wormbase_t2gene | sort) <(cat $wormbase_t2gene_part | sort)
+
+    [ "$status" -eq 0 ]
+}
+
+@test "Make a transcript to gene file and filter cDNAs to match (Ensembl)" {
     if  [ "$resume" = 'true' ] && [ -f "$filtered_cdnas" ]; then
         skip "$filtered_cdnas exists"
     fi
@@ -103,12 +166,28 @@ setup() {
     [ -f "$filtered_cdnas" ]
 }
 
-@test "Make sure transcripts were successfully filtered" {
+@test "Make a transcript to gene file and filter cDNAs to match (Wormbase)" {
+    if  [ "$resume" = 'true' ] && [ -f "$wormbase_filtered_cdnas" ]; then
+        skip "$wormbase_filtered_cdnas exists"
+    fi
+
+    run rm -rf $wormbase_filtered_cdnas && gtf2featureAnnotation.R --gtf-file $wormbase_part_test_gtf --version-transcripts --parse-cdnas $wormbase_test_cdna  --parse-cdna-field "transcript_id" --feature-type "transcript" --first-field "transcript_id" --output-file $wormbase_t2gene_part_matched --fields "transcript_id,gene_id" --no-header --filter-cdnas-output $wormbase_filtered_cdnas
+
+    [ "$status" -eq 0 ]
+    [ -f "$filtered_cdnas" ]
+}
+
+@test "Make sure transcripts were successfully filtered (Ensembl)" {
     run eval "zcat $filtered_cdnas | grep $test_gene_to_remove"  
     [ "$status" -eq 1 ]
 }
 
-@test "Make a gene-level annotation file and include missing gene info from cDNA FASTA headers" {
+@test "Make sure transcripts were successfully filtered (Wormbase)" {
+    run eval "zcat $wormbase_filtered_cdnas | grep $wormbase_test_gene_to_remove"  
+    [ "$status" -eq 1 ]
+}
+
+@test "Make a gene-level annotation file and include missing gene info from cDNA FASTA headers (Ensembl)" {
     if  [ "$resume" = 'true' ] && [ -f "$enriched_gene_anno" ]; then
         skip "$enriched_gene_anno  exists"
     fi
@@ -117,4 +196,15 @@ setup() {
 
     [ "$status" -eq 0 ]
     [ -f "$enriched_gene_anno" ]
+}
+
+@test "Make a gene-level annotation file and include missing gene info from cDNA FASTA headers (Wormbase)" {
+    if  [ "$resume" = 'true' ] && [ -f "$wormbase_enriched_gene_anno" ]; then
+        skip "$wormbase_enriched_gene_anno  exists"
+    fi
+
+    run rm -rf $wormbase_enriched_gene_anno && gtf2featureAnnotation.R --gtf-file $wormbase_part_test_gtf --version-transcripts --parse-cdnas $wormbase_test_cdna  --parse-cdna-field "gene_id" --feature-type "gene" --parse-cdna-names --first-field "gene_id" --output-file $wormbase_enriched_gene_anno
+
+    [ "$status" -eq 0 ]
+    [ -f "$wormbase_enriched_gene_anno" ]
 }

--- a/gtf2featureAnnotation.R
+++ b/gtf2featureAnnotation.R
@@ -237,7 +237,7 @@ if ( opt$feature_type == 'transcript' &&  all(c('transcript_id', 'transcript_ver
     anno$transcript_id <- versioned_transcripts
   } 
 }
-save.image()
+
 # If specified, filter down a provided cDNA FASTA file
 
 if (! is.null(opt$parse_cdnas)){

--- a/gtf2featureAnnotation.R
+++ b/gtf2featureAnnotation.R
@@ -239,7 +239,7 @@ if ( opt$feature_type == 'transcript' &&  all(c('transcript_id', 'transcript_ver
 }
 
 # If specified, filter down a provided cDNA FASTA file
-save.image()
+
 if (! is.null(opt$parse_cdnas)){
   
   # Derive annotation table from transcripts and use to augment GTF where necessary

--- a/gtf2featureAnnotation.R
+++ b/gtf2featureAnnotation.R
@@ -239,7 +239,7 @@ if ( opt$feature_type == 'transcript' &&  all(c('transcript_id', 'transcript_ver
 }
 save.image()
 # If specified, filter down a provided cDNA FASTA file
-
+save.image()
 if (! is.null(opt$parse_cdnas)){
   
   # Derive annotation table from transcripts and use to augment GTF where necessary
@@ -270,7 +270,7 @@ if (! is.null(opt$parse_cdnas)){
       print(paste("Info missing from GTF for", length(new_info), "supplied", opt$feature_type, "features annotated in cDNA headers, merging in the extra info."))
       
       # Limit new info to features not present in the GTF, and columns which are
-      anno <- plyr::rbind.fill(as.data.frame(anno), tinfo[match(new_info, tinfo[[opt$parse_cdna_field]]), colnames(tinfo) %in% colnames(anno)])
+      anno <- plyr::rbind.fill(as.data.frame(anno), tinfo[match(new_info, tinfo[[opt$parse_cdna_field]]), colnames(tinfo) %in% colnames(anno), drop = FALSE])
     }else{
       print("No new info found in cDNA headers wrt GTF")
     }

--- a/gtf2featureAnnotation.R
+++ b/gtf2featureAnnotation.R
@@ -143,13 +143,24 @@ if (is.na(opt$output_file)){
 # Try to get some annotation fields from the the transcript names themselves-
 # this will likely not work for non-Ensembl GTFs
 
-parse_ensembl_fasta_transcript_info <- function(tname){
-  description <- sub(".*description:(.*)", "\\1", tname)
-  tname <- sub(" description:.*", '', tname)
+parse_fasta_transcript_info <- function(tname, source=NULL){
+  if (source == 'ensembl'){
+    sep <- ':'
+  }else if (source == 'wormbase'){
+    sep <- '='
+  }else{
+    sep <- ':|='  
+  }
+  
+  description=NULL
+  if (grepl('description:', tname)){
+    description <- sub(".*description:(.*)", "\\1", tname)
+    tname <- sub(" description:.*", '', tname)
+  }
   tsplit <- unlist(strsplit(tname, ' '))
   names(tsplit) <- lapply(tsplit, function(x){
-    if (grepl(':', x[1])){
-      cnames <- unique(unlist(lapply(strsplit(x, ':'), function(y) y[1])))
+    if (grepl(sep, x[1])){
+      cnames <- unique(unlist(lapply(strsplit(x, sep, fixed=FALSE), function(y) y[1])))
       if (length(cnames) == 1){
         return(cnames)
       }else{
@@ -159,8 +170,10 @@ parse_ensembl_fasta_transcript_info <- function(tname){
   })
   names(tsplit)[1] <- 'transcript_id'
   tsplit <- tsplit[names(tsplit) != 'NULL']
-  tsplit <- sub('.*:(.*)', "\\1", tsplit)
-  tsplit['description'] <- description
+  tsplit <- sub(paste0('.*(', sep,')(.*)'), "\\2", tsplit)
+  if (! is.null(description)){                            
+    tsplit['description'] <- description
+  }
   names(tsplit) <- sub('^gene$', 'gene_id', names(tsplit))
   names(tsplit) <- sub('^gene_symbol$', 'gene_name', names(tsplit))
   tsplit['gene_id'] <- sub('\\.[0-9]+', '', tsplit['gene_id'])
@@ -232,7 +245,15 @@ if (! is.null(opt$parse_cdnas)){
   # Derive annotation table from transcripts and use to augment GTF where necessary
   
   print("Parsing annotation info from cDNA FASTA headers")
-  tinfo <- plyr::rbind.fill(lapply(names(cdna), parse_ensembl_fasta_transcript_info))
+  source <- NULL
+  if ('source' %in% colnames(anno)){
+    if (any(grepl('ensembl', anno$source))){
+      source <- 'ensembl' 
+    }else{
+      source <- tolower(as.character(anno$source[1]))
+    } 
+  }
+  tinfo <- plyr::rbind.fill(lapply(names(cdna), parse_fasta_transcript_info, source))
   
   # If we're not parsing the headers for annotation and our feature type is
   # transcript, then we can assume the transcript names are all we need.
@@ -240,7 +261,7 @@ if (! is.null(opt$parse_cdnas)){
   if (opt$feature_type == 'transcript' && is.null(opt$parse_cdna_names)){
     tinfo <- data.frame(cdna_transcript_names)
     colnames(tinfo) <- opt$parse_cdna_field  
-  }else{
+  }else if (opt$parse_cdna_field %in% colnames(anno) && opt$parse_cdna_field %in% colnames(tinfo)){
     new_info <- unique(tinfo[[opt$parse_cdna_field]][! tinfo[[opt$parse_cdna_field]] %in% anno[[opt$parse_cdna_field]]])
       
     # If we have transcripts with no annotation, see if we can get it from the fasta names

--- a/gtf2featureAnnotation.R
+++ b/gtf2featureAnnotation.R
@@ -143,10 +143,10 @@ if (is.na(opt$output_file)){
 # Try to get some annotation fields from the the transcript names themselves-
 # this will likely not work for non-Ensembl GTFs
 
-parse_fasta_transcript_info <- function(tname, source=NULL){
-  if (source == 'ensembl'){
+parse_fasta_transcript_info <- function(tname, fa_header_style=NULL){
+  if (fa_header_style == 'ensembl'){
     sep <- ':'
-  }else if (source == 'wormbase'){
+  }else if (fa_header_style == 'wormbase'){
     sep <- '='
   }else{
     sep <- ':|='  
@@ -237,7 +237,7 @@ if ( opt$feature_type == 'transcript' &&  all(c('transcript_id', 'transcript_ver
     anno$transcript_id <- versioned_transcripts
   } 
 }
-
+save.image()
 # If specified, filter down a provided cDNA FASTA file
 
 if (! is.null(opt$parse_cdnas)){
@@ -245,15 +245,15 @@ if (! is.null(opt$parse_cdnas)){
   # Derive annotation table from transcripts and use to augment GTF where necessary
   
   print("Parsing annotation info from cDNA FASTA headers")
-  source <- NULL
+  fa_header_style <- NULL
   if ('source' %in% colnames(anno)){
-    if (any(grepl('ensembl', anno$source))){
-      source <- 'ensembl' 
+    if (any(grepl('ensembl', anno$source)) || grepl('description:', names(cdna)[1])){
+      fa_header_style <- 'ensembl' 
     }else{
-      source <- tolower(as.character(anno$source[1]))
+      fa_header_style <- tolower(as.character(anno$source[1]))
     } 
   }
-  tinfo <- plyr::rbind.fill(lapply(names(cdna), parse_fasta_transcript_info, source))
+  tinfo <- plyr::rbind.fill(lapply(names(cdna), parse_fasta_transcript_info, fa_header_style))
   
   # If we're not parsing the headers for annotation and our feature type is
   # transcript, then we can assume the transcript names are all we need.

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -1,4 +1,8 @@
 name: test
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
 dependencies:
   - bats 
   - r-optparse 

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -1,4 +1,4 @@
-name: test
+name: base
 dependencies:
   - bats 
   - r-optparse 

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -1,4 +1,4 @@
-name: base
+name: test
 dependencies:
   - bats 
   - r-optparse 


### PR DESCRIPTION
This PR changes the way fasta headers for reference transcriptomes are parsed to augment annotations from GTF (the two are not always in sych in genome resources), and adds a missing sanity check or two.

Ensembl Fasta headers look like:

```
>ENST00000631435 cdna chromosome:GRCh38:CHR_HSCHR7_2_CTG6:142847306:142847317:1 gene:ENSG00000282253.1 gene_biotype:TR_D_gene transcript_biotype:TR_D_gene gene_symbol:TRBD1 description:T cell receptor beta diversity 1 [Source:HGNC Symbol;Acc:HGNC:12158]
```

While e.g. Wormbase headers look like:

```
>Smp_000020.1 gene=Smp_000020
```

This PR switches things to allow for '=' as a field/value separator, conditioning on the 'source' from the GTF file (where available) and the content of the header. 

In my testing this allows [this process](https://github.com/ebi-gene-expression-group/scxa-control-workflow/blob/c79bc35ddc88f703d01231dbe0862f8376a564e3/main.nf#L834) to correctly determine that the cDNA file for schistosoma mansoni does not contain any additional gene info for that species.

(I also switched the CI to use micromamba)