### PR TITLE
fix erroring with bad first field

### DIFF
--- a/gtf2featureAnnotation.R
+++ b/gtf2featureAnnotation.R
@@ -195,7 +195,7 @@ print(paste('Found', nrow(anno), 'features'))
 
 if (! is.na(opt$first_field)){
   if (! opt$first_field %in% colnames(anno)){
-    die(paste(first_field, 'is not a valid field'))
+    die(paste(opt$first_field, 'is not a valid field'))
   }
   anno <- anno[,c(opt$first_field, colnames(anno)[colnames(anno) != opt$first_field])]
 }


### PR DESCRIPTION
There’s an error with the errors right now (reported at https://nfcore.slack.com/archives/C045UNCS5R9/p1684922267900519), since `first_field` is referred to as a bare variable rather than a component of `opt`, as should be the case. This just fixes that. 